### PR TITLE
Fix malformed node args when enabling esm in swtc config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2.0.1
+
+- Fix malformed node arguments when enabling ESM in SWTC config.
+
 ## 2.0.0
 
 - BREAKING: Removed lifecycle hooks `containers` and `run` from swtc configuration file. This has been replaced by a new configuration object, see the [SWTC Documentation](https://brad-turner.github.io/swtc/) for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swtc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swtc",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swtc",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A thin wrapper around the testcontainers library, SWTC lets you easily start and configure a network of Docker services before running a node project.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/swtc.ts
+++ b/src/swtc.ts
@@ -23,7 +23,7 @@ export async function startWithTestContainers(config: SwtcConfig): Promise<void>
 
   const childProcessArgs = new Array<string>();
   // if (config.envFile) childProcessArgs.push(`--env-file=${config.envFile}`);
-  if (config.esm) childProcessArgs.push(`--loader ts-node/esm`);
+  if (config.esm) childProcessArgs.push(`--loader`, `ts-node/esm`);
   if (config.watch) childProcessArgs.push(`--watch`);
 
   spawn('node', [...childProcessArgs, config.entrypoint], { stdio: 'inherit' });


### PR DESCRIPTION
When testing enabling of the ESM option in the SWTC config, node's child process complained of an invalid argument. This PR fixes this by correctly spreading the ESM loader argument correctly.